### PR TITLE
Add jinja2 package to remove the vulnerability in component image

### DIFF
--- a/assets/designer/environments/component/context/conda_dependencies.yaml
+++ b/assets/designer/environments/component/context/conda_dependencies.yaml
@@ -8,3 +8,4 @@ dependencies:
   - azure-ml-component=={{latest-pypi-version}}
   - azureml-defaults=={{latest-pypi-version}}
   - pyarrow>=14.0.1
+  - Jinja2>=3.1.6


### PR DESCRIPTION
Fix the following vulnerability of jinje2 component image. This package is used by azureml-component and flask package
https://github.com/advisories/GHSA-cpwx-vrp4-4pq7